### PR TITLE
feat(codeowners): bubble up unowned file names

### DIFF
--- a/dist/commands/git/codeowners/check.js
+++ b/dist/commands/git/codeowners/check.js
@@ -67,8 +67,19 @@ export function gitCodeownersCheck(options = {}) {
         console.error('');
         console.error('❌ There are unowned files in the repository!');
         console.error('Please add the necessary OWNERSHIP files to appropriately tag owners.');
-        if (verbose && error instanceof Error) {
-            console.error('Error details:', error.message);
+        if (error && typeof error === 'object' && 'stdout' in error) {
+            const stdout = error.stdout?.toString().trim();
+            if (stdout) {
+                console.error('');
+                console.error('Unowned files:');
+                console.error(stdout);
+            }
+        }
+        if (error && typeof error === 'object' && 'stderr' in error) {
+            const stderr = error.stderr?.toString().trim();
+            if (stderr) {
+                console.error(stderr);
+            }
         }
         console.error('');
         process.exit(1);

--- a/dist/commands/hook/collate.js
+++ b/dist/commands/hook/collate.js
@@ -35,7 +35,7 @@ function parseFailureOutput(output) {
             message: 'CODEOWNERS files are out of sync',
         },
         {
-            marker: 'There are unowned files in the repository!',
+            marker: 'Unowned files:',
             message: 'Unowned files detected',
         },
     ];

--- a/docs/todo_items.md
+++ b/docs/todo_items.md
@@ -1,0 +1,23 @@
+# TODO Items
+
+## Consolidate type-narrowing in codeowners check error handling
+
+**File:** `src/commands/git/codeowners/check.ts` (lines 129-141)
+
+The `error && typeof error === 'object' && 'stdout' in error` pattern appears twice with near-identical structure for stdout and stderr. Consolidate into a single narrowing block:
+
+```typescript
+if (error && typeof error === 'object') {
+  const execError = error as { stdout?: Buffer | string; stderr?: Buffer | string };
+  const stdout = execError.stdout?.toString().trim();
+  const stderr = execError.stderr?.toString().trim();
+  if (stdout) {
+    console.error('');
+    console.error('Unowned files:');
+    console.error(stdout);
+  }
+  if (stderr) {
+    console.error(stderr);
+  }
+}
+```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tsutils",
-  "version": "0.21.0",
+  "version": "0.22.0",
   "description": "TypeScript command line utilities",
   "type": "module",
   "main": "./dist/index.js",

--- a/src/commands/git/codeowners/check.test.ts
+++ b/src/commands/git/codeowners/check.test.ts
@@ -203,9 +203,7 @@ describe('gitCodeownersCheck', () => {
       'Please add the necessary OWNERSHIP files to appropriately tag owners.'
     );
     expect(consoleErrorSpy).toHaveBeenCalledWith('Unowned files:');
-    expect(consoleErrorSpy).toHaveBeenCalledWith(
-      'lib/unowned_file.dart\nlib/another_unowned.dart'
-    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith('lib/unowned_file.dart\nlib/another_unowned.dart');
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });
 

--- a/src/commands/git/codeowners/check.test.ts
+++ b/src/commands/git/codeowners/check.test.ts
@@ -183,7 +183,13 @@ describe('gitCodeownersCheck', () => {
     // Mock execSync to succeed for generate but fail for unowned check
     vi.mocked(execSync).mockImplementation((command: string) => {
       if (command === 'coach codeowners unowned --check') {
-        throw new Error('Unowned files found');
+        const error = new Error('Unowned files found') as Error & {
+          stdout: Buffer;
+          stderr: Buffer;
+        };
+        error.stdout = Buffer.from('lib/unowned_file.dart\nlib/another_unowned.dart');
+        error.stderr = Buffer.from('');
+        throw error;
       }
       return '' as any;
     });
@@ -195,6 +201,10 @@ describe('gitCodeownersCheck', () => {
     expect(consoleErrorSpy).toHaveBeenCalledWith('❌ There are unowned files in the repository!');
     expect(consoleErrorSpy).toHaveBeenCalledWith(
       'Please add the necessary OWNERSHIP files to appropriately tag owners.'
+    );
+    expect(consoleErrorSpy).toHaveBeenCalledWith('Unowned files:');
+    expect(consoleErrorSpy).toHaveBeenCalledWith(
+      'lib/unowned_file.dart\nlib/another_unowned.dart'
     );
     expect(processExitSpy).toHaveBeenCalledWith(1);
   });

--- a/src/commands/git/codeowners/check.ts
+++ b/src/commands/git/codeowners/check.ts
@@ -124,9 +124,23 @@ export function gitCodeownersCheck(options: GitCodeownersCheckOptions = {}): voi
     console.error('');
     console.error('❌ There are unowned files in the repository!');
     console.error('Please add the necessary OWNERSHIP files to appropriately tag owners.');
-    if (verbose && error instanceof Error) {
-      console.error('Error details:', error.message);
+
+    // Show the unowned files from coach output
+    if (error && typeof error === 'object' && 'stdout' in error) {
+      const stdout = (error as { stdout: Buffer | string }).stdout?.toString().trim();
+      if (stdout) {
+        console.error('');
+        console.error('Unowned files:');
+        console.error(stdout);
+      }
     }
+    if (error && typeof error === 'object' && 'stderr' in error) {
+      const stderr = (error as { stderr: Buffer | string }).stderr?.toString().trim();
+      if (stderr) {
+        console.error(stderr);
+      }
+    }
+
     console.error('');
     process.exit(1);
   }

--- a/src/commands/hook/collate.ts
+++ b/src/commands/hook/collate.ts
@@ -53,7 +53,7 @@ function parseFailureOutput(output: string): { files: string[]; message?: string
       message: 'CODEOWNERS files are out of sync',
     },
     {
-      marker: 'There are unowned files in the repository!',
+      marker: 'Unowned files:',
       message: 'Unowned files detected',
     },
   ];


### PR DESCRIPTION
## Summary
- Codeowners check now captures and displays the actual unowned file names from `coach` output instead of a generic "Unowned files detected" message
- Fixes the collate parser marker to use `"Unowned files:"` so file names propagate to the collate failure summary

## Test plan
- [x] Existing codeowners check tests pass with updated assertions
- [x] Collate tests pass
- [ ] Run `tsu hook collate --codeowners` in a repo with unowned files and verify file names appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)