### PR TITLE
fix: resolve TypeScript and Prettier quality check issues

### DIFF
--- a/src/commands/git/codeowners/check.ts
+++ b/src/commands/git/codeowners/check.ts
@@ -67,10 +67,13 @@ export function gitCodeownersCheck(options: GitCodeownersCheckOptions = {}): voi
   ensureCondition(gitStatusAfter !== null, 'Error: Failed to get git status');
 
   // Compare git status before and after
-  // TypeScript knows these are non-null after ensureCondition checks
-  // Using type guards instead of assertions for better safety
+  // ensureCondition calls process.exit but doesn't narrow types, so add explicit guards
   /* v8 ignore next -- @preserve */
-  const changedFiles = getNewlyChangedFiles(gitStatusBefore, gitStatusAfter).filter(isCodeownersFile);
+  if (gitStatusBefore === null || gitStatusAfter === null) return;
+  /* v8 ignore next -- @preserve */
+  const changedFiles = getNewlyChangedFiles(gitStatusBefore, gitStatusAfter).filter(
+    isCodeownersFile
+  );
 
   if (changedFiles.length > 0) {
     console.error('');
@@ -142,6 +145,7 @@ function parseGitStatusEntries(status: string): Map<string, string> {
       }
 
       const [, state, rawPath] = match;
+      if (!state || !rawPath) return;
       const normalizedPath = rawPath.includes(' -> ') ? rawPath.split(' -> ').pop() : rawPath;
       if (normalizedPath) {
         entries.set(normalizedPath, state);

--- a/src/commands/hook/graphql/check.ts
+++ b/src/commands/hook/graphql/check.ts
@@ -10,7 +10,9 @@ import { setVerbose } from '../../../utils/verbose-state.js';
 export type DartHookGraphqlCheckOptions = ChangedFilesOptions;
 
 const GRAPHQL_GENERATED_SUFFIXES = new Set(
-  COMMON_DART_CODEGEN_SUFFIXES.filter((suffix) => suffix === '.gql.dart' || suffix === '.fakes.dart')
+  COMMON_DART_CODEGEN_SUFFIXES.filter(
+    (suffix) => suffix === '.gql.dart' || suffix === '.fakes.dart'
+  )
 );
 
 /**
@@ -100,10 +102,13 @@ export async function dartHookGraphqlCheck(
   ensureCondition(gitStatusAfter !== null, 'Error: Failed to get git status');
 
   // Compare git status before and after
-  // TypeScript knows these are non-null after ensureCondition checks
-  // Using type guards instead of assertions for better safety
+  // ensureCondition calls process.exit but doesn't narrow types, so add explicit guards
   /* v8 ignore next -- @preserve */
-  const changedFiles = getNewlyChangedFiles(gitStatusBefore, gitStatusAfter).filter(isGraphqlOwnedFile);
+  if (gitStatusBefore === null || gitStatusAfter === null) return;
+  /* v8 ignore next -- @preserve */
+  const changedFiles = getNewlyChangedFiles(gitStatusBefore, gitStatusAfter).filter(
+    isGraphqlOwnedFile
+  );
 
   if (changedFiles.length > 0) {
     console.error('');
@@ -139,6 +144,7 @@ function parseGitStatusEntries(status: string): Map<string, string> {
       }
 
       const [, state, rawPath] = match;
+      if (!state || !rawPath) return;
       const normalizedPath = rawPath.includes(' -> ') ? rawPath.split(' -> ').pop() : rawPath;
       if (normalizedPath) {
         entries.set(normalizedPath, state);

--- a/src/commands/upgrade.test.ts
+++ b/src/commands/upgrade.test.ts
@@ -49,12 +49,7 @@ describe('upgrade', () => {
 
     await expect(upgrade()).rejects.toThrow('process.exit(0)');
 
-    expect(versionUtils.upgradeFromGitHub).toHaveBeenCalledWith(
-      'bestdan',
-      'tsu',
-      'v0.7.0',
-      'pnpm'
-    );
+    expect(versionUtils.upgradeFromGitHub).toHaveBeenCalledWith('bestdan', 'tsu', 'v0.7.0', 'pnpm');
     expect(exitSpy).toHaveBeenCalledWith(0);
   });
 
@@ -68,12 +63,7 @@ describe('upgrade', () => {
 
     await expect(upgrade({ packageManager: 'pnpm' })).rejects.toThrow('process.exit(0)');
 
-    expect(versionUtils.upgradeFromGitHub).toHaveBeenCalledWith(
-      'bestdan',
-      'tsu',
-      'v0.7.0',
-      'pnpm'
-    );
+    expect(versionUtils.upgradeFromGitHub).toHaveBeenCalledWith('bestdan', 'tsu', 'v0.7.0', 'pnpm');
   });
 
   it('should show verbose output when verbose flag is enabled and up-to-date', async () => {


### PR DESCRIPTION
## Summary
- **Fix 6 TypeScript errors** in `codeowners/check.ts` and `graphql/check.ts`: Add explicit null guards after `ensureCondition()` calls (which call `process.exit` but don't narrow types), and add undefined checks for regex match destructuring of `state`/`rawPath`
- **Fix Prettier formatting** in 3 files: line length violations in `codeowners/check.ts`, `graphql/check.ts`, and `upgrade.test.ts`

## Test plan
- [x] `pnpm typecheck` passes (0 errors)
- [x] `pnpm lint` passes (ESLint + Prettier)
- [x] `pnpm format:check` passes

Supersedes #189 (rebased onto correct base branch).

https://claude.ai/code/session_01RobTdhpRAXuPkyQ8CknbWd