### PR TITLE
test(git): cover worktrees, untracked files, and the OWNERSHIP-deletion gap

### DIFF
--- a/src/commands/git/utils/changed-files/get-all-changed-files-with-status.test.ts
+++ b/src/commands/git/utils/changed-files/get-all-changed-files-with-status.test.ts
@@ -75,4 +75,53 @@ describe('getAllChangedFilesWithStatus', () => {
       rmSync(tempDir, { recursive: true, force: true });
     }
   });
+
+  it('should ignore untracked files in push mode', () => {
+    const tempDir = initRepo();
+    try {
+      writeFileSync(join(tempDir, 'a.txt'), 'a');
+      execSync('git add .', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git commit -m "initial"', { cwd: tempDir, stdio: 'pipe' });
+
+      execSync('git checkout -b feature', { cwd: tempDir, stdio: 'pipe' });
+      writeFileSync(join(tempDir, 'tracked.txt'), 'new');
+      execSync('git add tracked.txt', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git commit -m "add tracked"', { cwd: tempDir, stdio: 'pipe' });
+      // Untracked working-tree clutter (e.g. generated files, scratch dirs)
+      // must not influence what the pre-push hook considers changed.
+      writeFileSync(join(tempDir, 'untracked.txt'), 'junk');
+
+      const result = getAllChangedFilesWithStatus({ baseBranch: 'main' }, tempDir);
+      expect(result).toEqual([{ path: 'tracked.txt', status: 'A' }]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('should exclude a committed OWNERSHIP deletion (--diff-filter=ACMR)', () => {
+    // Documents a known gap: removing an OWNERSHIP file can orphan a directory,
+    // but the deletion is stripped by `--diff-filter=ACMR`, so it never reaches
+    // isCodeownersRelevant and the codeowners check is skipped for that push.
+    const tempDir = initRepo();
+    try {
+      writeFileSync(join(tempDir, 'OWNERSHIP'), 'team: x\n');
+      writeFileSync(join(tempDir, 'a.txt'), 'a');
+      execSync('git add .', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git commit -m "initial"', { cwd: tempDir, stdio: 'pipe' });
+
+      execSync('git checkout -b feature', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git rm OWNERSHIP', { cwd: tempDir, stdio: 'pipe' });
+      execSync('git commit -m "remove ownership"', { cwd: tempDir, stdio: 'pipe' });
+
+      const result = getAllChangedFilesWithStatus({ baseBranch: 'main' }, tempDir);
+      expect(result).toEqual([]);
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  // The deletion above is silently dropped, so codeowners never re-validates a
+  // directory whose OWNERSHIP file was removed. Closing this needs a detection
+  // change (surface ownership-file deletions); see PR #193 review discussion.
+  it.todo('should surface deleted OWNERSHIP/CODEOWNERS files so codeowners can re-validate');
 });

--- a/src/commands/git/utils/changed-files/is-codeowners-relevant.test.ts
+++ b/src/commands/git/utils/changed-files/is-codeowners-relevant.test.ts
@@ -30,4 +30,16 @@ describe('isCodeownersRelevant', () => {
   it('should be false for an empty change set', () => {
     expect(isCodeownersRelevant([])).toBe(false);
   });
+
+  it('should be false for a deleted non-ownership file', () => {
+    expect(isCodeownersRelevant([{ path: 'lib/old.dart', status: 'D' }])).toBe(false);
+  });
+
+  it('should be true for a deleted OWNERSHIP file (matched by name)', () => {
+    // The gate keys off the file name, so it would correctly flag a deleted
+    // OWNERSHIP file. In practice a deletion never reaches this gate: detection
+    // strips it via `--diff-filter=ACMR` before this runs. See the deletion
+    // case in get-all-changed-files-with-status.test.ts.
+    expect(isCodeownersRelevant([{ path: 'lib/feature/OWNERSHIP', status: 'D' }])).toBe(true);
+  });
 });

--- a/src/commands/git/utils/range/get-files-to-push-with-status.test.ts
+++ b/src/commands/git/utils/range/get-files-to-push-with-status.test.ts
@@ -89,4 +89,71 @@ describe('getFilesToPushWithStatus', () => {
       rmSync(remoteDir, { recursive: true, force: true });
     }
   });
+
+  describe('in a linked worktree', () => {
+    it('reports feature-branch files with status from a worktree (no remote)', () => {
+      const tempDir = initRepo();
+      const worktreeParent = realpathSync(mkdtempSync(join(tmpdir(), 'git-worktree-')));
+      const worktreeDir = join(worktreeParent, 'wt');
+      try {
+        writeFileSync(join(tempDir, 'a.txt'), 'a');
+        execSync('git add .', { cwd: tempDir, stdio: 'pipe' });
+        execSync('git commit -m "initial"', { cwd: tempDir, stdio: 'pipe' });
+
+        execSync(`git worktree add -b feature "${worktreeDir}"`, { cwd: tempDir, stdio: 'pipe' });
+        writeFileSync(join(worktreeDir, 'a.txt'), 'changed');
+        writeFileSync(join(worktreeDir, 'b.txt'), 'new');
+        execSync('git add .', { cwd: worktreeDir, stdio: 'pipe' });
+        execSync('git commit -m "feature"', { cwd: worktreeDir, stdio: 'pipe' });
+
+        const result = getFilesToPushWithStatus({
+          cwd: realpathSync(worktreeDir),
+          baseBranch: 'main',
+        });
+        expect(result).toEqual([
+          { path: 'a.txt', status: 'M' },
+          { path: 'b.txt', status: 'A' },
+        ]);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+        rmSync(worktreeParent, { recursive: true, force: true });
+      }
+    });
+
+    it('reports only unpushed files with status from a worktree (with remote)', () => {
+      const tempDir = initRepo();
+      const remoteDir = realpathSync(mkdtempSync(join(tmpdir(), 'git-remote-')));
+      const worktreeParent = realpathSync(mkdtempSync(join(tmpdir(), 'git-worktree-')));
+      const worktreeDir = join(worktreeParent, 'wt');
+      try {
+        writeFileSync(join(tempDir, 'initial.txt'), 'initial');
+        execSync('git add .', { cwd: tempDir, stdio: 'pipe' });
+        execSync('git commit -m "initial"', { cwd: tempDir, stdio: 'pipe' });
+
+        execSync('git init --bare', { cwd: remoteDir, stdio: 'pipe' });
+        execSync(`git remote add origin "${remoteDir}"`, { cwd: tempDir, stdio: 'pipe' });
+        execSync('git push -u origin main', { cwd: tempDir, stdio: 'pipe' });
+
+        execSync(`git worktree add -b feature "${worktreeDir}"`, { cwd: tempDir, stdio: 'pipe' });
+        writeFileSync(join(worktreeDir, 'feature1.txt'), 'work 1');
+        execSync('git add .', { cwd: worktreeDir, stdio: 'pipe' });
+        execSync('git commit -m "work 1"', { cwd: worktreeDir, stdio: 'pipe' });
+        execSync('git push -u origin feature', { cwd: worktreeDir, stdio: 'pipe' });
+
+        writeFileSync(join(worktreeDir, 'feature2.txt'), 'work 2');
+        execSync('git add .', { cwd: worktreeDir, stdio: 'pipe' });
+        execSync('git commit -m "work 2"', { cwd: worktreeDir, stdio: 'pipe' });
+
+        const result = getFilesToPushWithStatus({
+          cwd: realpathSync(worktreeDir),
+          baseBranch: 'main',
+        });
+        expect(result).toEqual([{ path: 'feature2.txt', status: 'A' }]);
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true });
+        rmSync(remoteDir, { recursive: true, force: true });
+        rmSync(worktreeParent, { recursive: true, force: true });
+      }
+    });
+  });
 });


### PR DESCRIPTION
Stacks on #193. Adds the coverage that PR's review surfaced as missing. All three areas were exercised manually against the #193 build; this locks them in as tests.

## What this adds

`src`-only — the compiled `*.test.js` are gitignored, so there are no `dist` changes.

**Worktrees** — `get-files-to-push-with-status.test.ts`
- `getFilesToPushWithStatus` called from inside a linked `git worktree`, **no remote** → full `main...HEAD` range with statuses.
- same, **with a remote** → only the unpushed file.

Confirms detection and the `origin/<branch>` remote resolution work when `.git` is a file rather than a directory (the case the suite didn't cover).

**Untracked files** — `get-all-changed-files-with-status.test.ts`
- untracked working-tree files are ignored in push mode (only the tracked add is detected).

**OWNERSHIP-deletion gap** — `get-all-changed-files-with-status.test.ts` + `is-codeowners-relevant.test.ts`
- characterizes that a committed `OWNERSHIP` deletion is stripped by `--diff-filter=ACMR`, so it never reaches `isCodeownersRelevant` and codeowners is skipped for that push.
- `isCodeownersRelevant` *would* flag a deleted `OWNERSHIP` by name (added test) — so the gap is in detection, not the gate.
- an `it.todo` marks the behavior to close (surface ownership-file deletions so codeowners can re-validate).

## Verification
- Changed test files: **19 passed + 1 todo**.
- `prettier --check`, `eslint`, `tsc --noEmit`: clean.

See the review comment on #193 for context (this PR, plus a separate `vitest.config` note about nested-worktree `dist/` test pollution).
