### PR TITLE
fix(package): rename to @bestdan/tsu and drop the tsutils bin

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-`tsutils` (aliased as `tsu`) is a TypeScript CLI utilities package focused on git operations and file manipulation. The package is designed with pipe-friendliness in mind, following Unix philosophy of composable, single-purpose tools. It can be used both as a CLI tool and as a library for programmatic use.
+`tsu` is a TypeScript CLI utilities package focused on git operations and file manipulation. The package is designed with pipe-friendliness in mind, following Unix philosophy of composable, single-purpose tools. It can be used both as a CLI tool and as a library for programmatic use.
 
 ## Key Architecture Principles
 
@@ -207,4 +207,4 @@ All functions handle errors gracefully and work from any subdirectory within a g
 
 - **CLI binary**: `src/cli.ts` → compiled to `dist/cli.js` (shebang included)
 - **Library exports**: `src/index.ts` → compiled to `dist/index.js`
-- **Package bins**: Both `tsutils` and `tsu` aliases point to `dist/cli.js`
+- **Package bin**: `tsu` points to `dist/cli.js`

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# tsutils
+# tsu
 
 TypeScript command line utilities package.
 
@@ -54,27 +54,27 @@ chmod +x .git/hooks/pre-push
 # Run all checks concurrently, collate results
 tsu hook format --verbose
 
-# Check and upgrade tsutils
-tsutils check version --verbose
-tsutils upgrade --verbose
+# Check and upgrade tsu
+tsu check version --verbose
+tsu upgrade --verbose
 
 # Check external dependencies
-tsutils check externals --verbose
+tsu check externals --verbose
 
 # Check if in a git repository
-tsutils git check && echo "In a git repo"
+tsu git check && echo "In a git repo"
 
 # Get git root path
-cd "$(tsutils git root)"
+cd "$(tsu git root)"
 
 # Show changed files
-tsutils git changed
+tsu git changed
 
 # Format check for Dart files (git hook)
-tsutils hook format check
+tsu hook format check
 
 # Filter files by extension
-tsutils git changed | tsutils files filter --suffix .ts
+tsu git changed | tsu files filter --suffix .ts
 ```
 
 ### Command Design Philosophy
@@ -124,7 +124,7 @@ src/
 
 ## Error Logging and Diagnostics
 
-tsutils includes a **privacy-focused local error logging system** to help diagnose issues:
+tsu includes a **privacy-focused local error logging system** to help diagnose issues:
 
 - 🔒 **Local-only**: All error logs stay on your machine
 - 🛡️ **Privacy-first**: Automatically sanitizes sensitive data

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,7 +11,7 @@ We release patches for security vulnerabilities. Currently supported versions:
 
 ## Reporting a Vulnerability
 
-We take the security of tsutils seriously. If you believe you have found a security vulnerability, please report it to us privately.
+We take the security of tsu seriously. If you believe you have found a security vulnerability, please report it to us privately.
 
 **Please do not report security vulnerabilities through public GitHub issues.**
 
@@ -58,7 +58,7 @@ When contributing to this project:
 
 ### For Users
 
-When using tsutils:
+When using tsu:
 
 1. **Keep updated**: Always use the latest stable version
 2. **Review permissions**: Understand what permissions the tool requires

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -33,10 +33,7 @@ const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 'utf-8'));
 const program = new Command();
-program
-    .name('tsutils')
-    .description('TypeScript command line utilities')
-    .version(packageJson.version);
+program.name('tsu').description('TypeScript command line utilities').version(packageJson.version);
 const check = program.command('check').description('Check system dependencies and environment');
 check
     .command('externals')
@@ -47,14 +44,14 @@ check
 });
 check
     .command('version')
-    .description('Check if tsutils is on the most recent version')
+    .description('Check if tsu is on the most recent version')
     .option('-v, --verbose', 'show human-readable status messages (output to stderr)')
     .action(async (options) => {
     await checkVersion(options);
 });
 program
     .command('upgrade')
-    .description('Upgrade tsutils to the latest version from GitHub')
+    .description('Upgrade tsu to the latest version from GitHub')
     .option('-v, --verbose', 'show progress messages (output to stderr)')
     .option('-p, --package-manager <manager>', 'package manager to use (npm, pnpm, or yarn)', 'npm')
     .action(async (options) => {

--- a/dist/commands/files/filter/suffix.js
+++ b/dist/commands/files/filter/suffix.js
@@ -35,7 +35,7 @@ export function filesFilter(suffixPatterns, options = {}) {
         const error = new Error('This command expects input from stdin (pipe)');
         logError(error, `tsu files filter suffix ${suffixPatterns.join(' ')}`);
         console.error('Error: This command expects input from stdin (pipe)');
-        console.error('Usage: tsutils git changed | tsutils files filter suffix .g.dart');
+        console.error('Usage: tsu git changed | tsu files filter suffix .g.dart');
         process.exit(1);
     }
 }

--- a/dist/utils/version.js
+++ b/dist/utils/version.js
@@ -20,7 +20,7 @@ export async function getLatestGitHubVersion(owner, repo) {
         const response = await fetch(url, {
             headers: {
                 Accept: 'application/vnd.github.v3+json',
-                'User-Agent': 'tsutils-cli',
+                'User-Agent': 'tsu-cli',
             },
         });
         if (!response.ok) {

--- a/docs/check.md
+++ b/docs/check.md
@@ -4,7 +4,7 @@ Commands for checking system dependencies and environment.
 
 ## check externals
 
-Check if external dependencies are installed. This command verifies the presence of optional external tools used by various tsutils commands.
+Check if external dependencies are installed. This command verifies the presence of optional external tools used by various tsu commands.
 
 **Usage:**
 
@@ -85,7 +85,7 @@ tsu check externals --verbose || echo "Please install missing dependencies"
 
 ## check version
 
-Check if tsutils is on the most recent version by comparing against the latest GitHub release.
+Check if tsu is on the most recent version by comparing against the latest GitHub release.
 
 **Usage:**
 

--- a/docs/dart.md
+++ b/docs/dart.md
@@ -5,9 +5,9 @@ Dart-related utilities for working with Dart/Flutter projects.
 ## Available Commands
 
 ```bash
-tsutils dart check                    # Check if in a Dart package
-tsutils dart root                     # Get Dart package root
-tsutils dart changed                  # Show changed Dart files
+tsu dart check                    # Check if in a Dart package
+tsu dart root                     # Get Dart package root
+tsu dart changed                  # Show changed Dart files
 ```
 
 For git / claude hook commands (format, analyze, dcm, graphql), see the [hook documentation](hook.md).

--- a/docs/error-logging.md
+++ b/docs/error-logging.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-tsutils includes a local error logging system designed for open-source CLI tools. This system helps users and maintainers diagnose issues while respecting user privacy.
+tsu includes a local error logging system designed for open-source CLI tools. This system helps users and maintainers diagnose issues while respecting user privacy.
 
 ## Key Features
 
@@ -40,7 +40,7 @@ export TSU_LOG_DIR=/path/to/custom/logs
 When an error occurs, the following information is recorded in `~/.tsu/logs/errors.log`:
 
 - **Timestamp**: When the error occurred
-- **Version**: The version of tsutils you're running
+- **Version**: The version of tsu you're running
 - **Node Version**: Your Node.js version
 - **Platform**: Your operating system (linux, darwin, win32, etc.)
 - **Command**: The command that was executed
@@ -180,7 +180,7 @@ rm ~/.tsu/logs/errors.log
 
 ## For Contributors
 
-If you're contributing to tsutils and want to add error logging to new commands:
+If you're contributing to tsu and want to add error logging to new commands:
 
 ```typescript
 import { logError } from '../utils/error-logger.js';

--- a/docs/files.md
+++ b/docs/files.md
@@ -5,7 +5,7 @@ File-related utilities for filtering and processing files.
 ## Available Commands
 
 ```bash
-tsutils files filter [options]        # Filter files by suffix/extension
+tsu files filter [options]        # Filter files by suffix/extension
 ```
 
 ## Command Details
@@ -21,13 +21,13 @@ Filter files by suffix or extension. Reads file paths from stdin and outputs fil
 **Example usage:**
 ```bash
 # Filter only TypeScript files from changed files
-tsutils git changed | tsutils files filter --suffix .ts
+tsu git changed | tsu files filter --suffix .ts
 
 # Filter Dart and TypeScript files
-tsutils git changed | tsutils files filter --suffix .dart --suffix .ts
+tsu git changed | tsu files filter --suffix .dart --suffix .ts
 
 # Combine with other commands
-tsutils git changed --all | tsutils files filter --suffix .json | xargs cat
+tsu git changed --all | tsu files filter --suffix .json | xargs cat
 ```
 
 ## Pipe-Friendly Output

--- a/docs/git.md
+++ b/docs/git.md
@@ -5,16 +5,16 @@ Git-related utilities for working with git repositories.
 ## Available Commands
 
 ```bash
-tsutils git check              # Check if in a git repository (exit code only)
-tsutils git root               # Get git root path
-tsutils git changed            # Show changed files
-tsutils git changed --staged   # Show only staged files
-tsutils git changed --all      # Show all changes with status prefix
-tsutils git branch             # Get current branch name
-tsutils git is-main            # Check if on main branch
-tsutils git commit-msg         # Generate commit message using Claude CLI
-tsutils git pr-description     # Generate PR description using Claude CLI
-tsutils git codeowners check   # Check if CODEOWNERS files are in sync
+tsu git check              # Check if in a git repository (exit code only)
+tsu git root               # Get git root path
+tsu git changed            # Show changed files
+tsu git changed --staged   # Show only staged files
+tsu git changed --all      # Show all changes with status prefix
+tsu git branch             # Get current branch name
+tsu git is-main            # Check if on main branch
+tsu git commit-msg         # Generate commit message using Claude CLI
+tsu git pr-description     # Generate PR description using Claude CLI
+tsu git codeowners check   # Check if CODEOWNERS files are in sync
 ```
 
 ## Pipe-Friendly Output
@@ -23,50 +23,50 @@ All git commands output clean, parseable data to **stdout** by default, making t
 
 ```bash
 # Boolean checks with git check (exit code only, no output)
-if tsutils git check; then
+if tsu git check; then
   echo "This is a git repository"
 fi
 
-tsutils git check && echo "In a git repo" || echo "Not a git repo"
+tsu git check && echo "In a git repo" || echo "Not a git repo"
 
 # Get git root and cd into it
-cd "$(tsutils git root)"
+cd "$(tsu git root)"
 
 # Count changed files
-tsutils git changed | wc -l
+tsu git changed | wc -l
 
 # Filter only staged files from all changes
-tsutils git changed --all | grep "^staged:" | cut -d: -f2
+tsu git changed --all | grep "^staged:" | cut -d: -f2
 
 # Process each changed file
-tsutils git changed | xargs -I {} echo "Processing: {}"
+tsu git changed | xargs -I {} echo "Processing: {}"
 
 # Get just the file extensions of changed files
-tsutils git changed | xargs -n1 basename | grep -o '\.[^.]*$' | sort | uniq
+tsu git changed | xargs -n1 basename | grep -o '\.[^.]*$' | sort | uniq
 
 # Use with other git commands
-tsutils git changed --staged | xargs git reset
+tsu git changed --staged | xargs git reset
 
 # Pipe to other tools
-tsutils git changed | fzf | xargs code
+tsu git changed | fzf | xargs code
 
 # Combine git check and git root
-tsutils git check && cd "$(tsutils git root)" && echo "Moved to $(pwd)"
+tsu git check && cd "$(tsu git root)" && echo "Moved to $(pwd)"
 
 # Generate commit message and pipe to git commit
-tsutils git commit-msg | git commit -F -
+tsu git commit-msg | git commit -F -
 
 # Generate commit message and review in editor before committing
-tsutils git commit-msg > /tmp/commit-msg.txt && vim /tmp/commit-msg.txt && git commit -F /tmp/commit-msg.txt
+tsu git commit-msg > /tmp/commit-msg.txt && vim /tmp/commit-msg.txt && git commit -F /tmp/commit-msg.txt
 
 # Generate PR description and copy to clipboard (macOS)
-tsutils git pr-description | pbcopy
+tsu git pr-description | pbcopy
 
 # Generate PR description and save to file
-tsutils git pr-description > pr-description.md
+tsu git pr-description > pr-description.md
 
 # Use PR description with gh CLI to create PR
-gh pr create --title "Feature: $(git branch --show-current)" --body "$(tsutils git pr-description)"
+gh pr create --title "Feature: $(git branch --show-current)" --body "$(tsu git pr-description)"
 ```
 
 ## Command Details
@@ -77,7 +77,7 @@ Returns exit code only (0=is git repo, 1=not). No stdout output. Perfect for con
 
 ### `git root`
 
-Outputs the git root path to stdout. Perfect for `cd "$(tsutils git root)"`.
+Outputs the git root path to stdout. Perfect for `cd "$(tsu git root)"`.
 
 ### `git changed`
 

--- a/docs/hook.md
+++ b/docs/hook.md
@@ -9,12 +9,12 @@ Git / Claude hook utilities for Dart/Flutter projects.
 ## Available Commands
 
 ```bash
-tsutils hook format check        # Format Dart files about to be pushed (for git hooks)
-tsutils hook analysis check      # Run dart analyze on Dart files about to be pushed
-tsutils hook fix check           # Run dart fix on Dart files about to be pushed
-tsutils hook dcm fix check       # Run DCM fix on Dart files about to be pushed (for git hooks)
-tsutils hook dcm analyze check   # Run DCM analyze on Dart files about to be pushed
-tsutils hook graphql check       # Check GraphQL codegen is up to date (for git hooks)
+tsu hook format check        # Format Dart files about to be pushed (for git hooks)
+tsu hook analysis check      # Run dart analyze on Dart files about to be pushed
+tsu hook fix check           # Run dart fix on Dart files about to be pushed
+tsu hook dcm fix check       # Run DCM fix on Dart files about to be pushed (for git hooks)
+tsu hook dcm analyze check   # Run DCM analyze on Dart files about to be pushed
+tsu hook graphql check       # Check GraphQL codegen is up to date (for git hooks)
 ```
 
 ## File Filtering Options
@@ -29,16 +29,16 @@ By default, all hook commands check **files that would be pushed** (commits on y
 **Examples:**
 ```bash
 # Check files to be pushed (default)
-tsutils hook format check
+tsu hook format check
 
 # Check only staged files
-tsutils hook format check --staged
+tsu hook format check --staged
 
 # Check all changes including unstaged
-tsutils hook format check --all
+tsu hook format check --all
 
 # Compare against develop branch instead of main
-tsutils hook format check --base-branch develop
+tsu hook format check --base-branch develop
 ```
 
 ## Command Details
@@ -63,7 +63,7 @@ Formats Dart files about to be pushed (excluding generated files) and exits with
 **Example usage in git hooks:**
 ```bash
 # In .git/hooks/pre-push or lefthook.yml
-tsutils hook format check || exit 1
+tsu hook format check || exit 1
 ```
 
 ### `hook analysis check`
@@ -85,7 +85,7 @@ Runs dart analyze on Dart files about to be pushed (excluding generated files) a
 **Example usage in git hooks:**
 ```bash
 # In .git/hooks/pre-push or lefthook.yml
-tsutils hook analysis check || exit 1
+tsu hook analysis check || exit 1
 ```
 
 ### `hook fix check`
@@ -108,7 +108,7 @@ Runs dart fix on Dart files about to be pushed (excluding generated files) and e
 **Example usage in git hooks:**
 ```bash
 # In .git/hooks/pre-push or lefthook.yml
-tsutils hook fix check || exit 1
+tsu hook fix check || exit 1
 ```
 
 ### `hook dcm fix check`
@@ -132,7 +132,7 @@ Runs DCM fix on Dart files about to be pushed (excluding generated files) and ex
 **Example usage in git hooks:**
 ```bash
 # In .git/hooks/pre-push or lefthook.yml
-tsutils hook dcm fix check || exit 1
+tsu hook dcm fix check || exit 1
 ```
 
 ### `hook dcm analyze check`
@@ -154,7 +154,7 @@ Runs DCM analyze on Dart files about to be pushed (excluding generated files) an
 **Example usage in git hooks:**
 ```bash
 # In .git/hooks/pre-push or lefthook.yml
-tsutils hook dcm analyze check || exit 1
+tsu hook dcm analyze check || exit 1
 ```
 
 ### `hook graphql check`
@@ -178,7 +178,7 @@ Checks if GraphQL files have been modified and runs code generation (`melos run 
 **Example usage in git hooks:**
 ```bash
 # In .git/hooks/pre-push or lefthook.yml
-tsutils hook graphql check || exit 1
+tsu hook graphql check || exit 1
 ```
 
 ## Verbose Mode

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,6 +1,6 @@
 # Release Management
 
-This document describes the automated build and release tracking system for tsutils.
+This document describes the automated build and release tracking system for tsu.
 
 ## Overview
 

--- a/docs/security-best-practices.md
+++ b/docs/security-best-practices.md
@@ -1,6 +1,6 @@
 # Security Best Practices
 
-This document outlines security best practices for both contributors and users of tsutils.
+This document outlines security best practices for both contributors and users of tsu.
 
 ## For Contributors
 
@@ -208,7 +208,7 @@ npm install -g github:bestdan/tsu
 
 ### 2. Update Regularly
 
-Keep tsutils updated to receive security patches:
+Keep tsu updated to receive security patches:
 
 ```bash
 # Check current version against latest
@@ -228,7 +228,7 @@ Review what permissions the tool requires:
 
 ### 4. Trust Boundary
 
-Understand that tsutils executes:
+Understand that tsu executes:
 - Git commands
 - Dart SDK commands (if installed)
 - DCM (if installed)

--- a/docs/upgrade.md
+++ b/docs/upgrade.md
@@ -1,10 +1,10 @@
 # Upgrade Command
 
-Self-upgrade tsutils to the latest version from the GitHub repository.
+Self-upgrade tsu to the latest version from the GitHub repository.
 
 ## upgrade
 
-Upgrades tsutils from GitHub to the latest version. This command first checks if an update is available, then uses your specified package manager to install the latest version from GitHub.
+Upgrades tsu from GitHub to the latest version. This command first checks if an update is available, then uses your specified package manager to install the latest version from GitHub.
 
 **Usage:**
 
@@ -76,7 +76,7 @@ Automatic upgrade in script:
 #!/bin/bash
 # Ensure we're on the latest version
 if tsu check version | grep -q "update_available: true"; then
-  echo "Upgrading tsutils..."
+  echo "Upgrading tsu..."
   tsu upgrade --package-manager pnpm --verbose
 fi
 ```
@@ -97,5 +97,5 @@ fi
 
 ## Related Commands
 
-- [`check version`](./check.md#check-version) - Check if tsutils is on the most recent version
+- [`check version`](./check.md#check-version) - Check if tsu is on the most recent version
 - [`check externals`](./check.md#check-externals) - Check if external dependencies are installed

--- a/package.json
+++ b/package.json
@@ -1,12 +1,11 @@
 {
-  "name": "tsutils",
-  "version": "0.26.0",
+  "name": "@bestdan/tsu",
+  "version": "0.27.0",
   "description": "TypeScript command line utilities",
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
   "bin": {
-    "tsutils": "./dist/cli.js",
     "tsu": "./dist/cli.js"
   },
   "files": [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -37,10 +37,7 @@ const packageJson = JSON.parse(readFileSync(join(__dirname, '../package.json'), 
 
 const program = new Command();
 
-program
-  .name('tsutils')
-  .description('TypeScript command line utilities')
-  .version(packageJson.version);
+program.name('tsu').description('TypeScript command line utilities').version(packageJson.version);
 
 // Check subcommand namespace
 const check = program.command('check').description('Check system dependencies and environment');
@@ -55,7 +52,7 @@ check
 
 check
   .command('version')
-  .description('Check if tsutils is on the most recent version')
+  .description('Check if tsu is on the most recent version')
   .option('-v, --verbose', 'show human-readable status messages (output to stderr)')
   .action(async (options: { verbose?: boolean }) => {
     await checkVersion(options);
@@ -64,7 +61,7 @@ check
 // Upgrade command
 program
   .command('upgrade')
-  .description('Upgrade tsutils to the latest version from GitHub')
+  .description('Upgrade tsu to the latest version from GitHub')
   .option('-v, --verbose', 'show progress messages (output to stderr)')
   .option('-p, --package-manager <manager>', 'package manager to use (npm, pnpm, or yarn)', 'npm')
   .action(async (options: { verbose?: boolean; packageManager?: 'npm' | 'pnpm' | 'yarn' }) => {

--- a/src/commands/check/externals.ts
+++ b/src/commands/check/externals.ts
@@ -6,7 +6,7 @@ export interface CheckExternalsOptions {
 }
 
 /**
- * External dependencies that the tsutils package may use
+ * External dependencies that the tsu package may use
  */
 interface ExternalDependency {
   command: string;

--- a/src/commands/check/version.ts
+++ b/src/commands/check/version.ts
@@ -10,7 +10,7 @@ const GITHUB_OWNER = 'bestdan';
 const GITHUB_REPO = 'tsu';
 
 /**
- * Check if tsutils is on the most recent version.
+ * Check if tsu is on the most recent version.
  * Compares the current installed version against the latest GitHub release.
  * Outputs version information to stdout in a parseable format.
  * In verbose mode, also outputs human-readable messages to stderr.

--- a/src/commands/files/filter/suffix.ts
+++ b/src/commands/files/filter/suffix.ts
@@ -62,7 +62,7 @@ export function filesFilter(suffixPatterns: string[], options: FilesFilterOption
     const error = new Error('This command expects input from stdin (pipe)');
     logError(error, `tsu files filter suffix ${suffixPatterns.join(' ')}`);
     console.error('Error: This command expects input from stdin (pipe)');
-    console.error('Usage: tsutils git changed | tsutils files filter suffix .g.dart');
+    console.error('Usage: tsu git changed | tsu files filter suffix .g.dart');
     process.exit(1);
   }
 }

--- a/src/commands/upgrade.ts
+++ b/src/commands/upgrade.ts
@@ -10,7 +10,7 @@ const GITHUB_OWNER = 'bestdan';
 const GITHUB_REPO = 'tsu';
 
 /**
- * Upgrade tsutils from GitHub to the latest version.
+ * Upgrade tsu from GitHub to the latest version.
  * First checks if an update is available, then uses the specified package manager
  * to install from GitHub.
  * In verbose mode, outputs progress messages to stderr.

--- a/src/utils/error-logger.ts
+++ b/src/utils/error-logger.ts
@@ -28,7 +28,7 @@ export interface ErrorContext {
    */
   timestamp: string;
   /**
-   * Version of tsutils
+   * Version of tsu
    */
   version: string;
   /**

--- a/src/utils/version.ts
+++ b/src/utils/version.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 /**
- * Get the current installed version of tsutils from package.json
+ * Get the current installed version of tsu from package.json
  * @returns The current version string
  */
 export function getCurrentVersion(): string {
@@ -34,7 +34,7 @@ export async function getLatestGitHubVersion(owner: string, repo: string): Promi
     const response = await fetch(url, {
       headers: {
         Accept: 'application/vnd.github.v3+json',
-        'User-Agent': 'tsutils-cli',
+        'User-Agent': 'tsu-cli',
       },
     });
 
@@ -99,13 +99,13 @@ export async function checkForUpdate(
 }
 
 /**
- * Detect which package manager was used to install tsutils globally
+ * Detect which package manager was used to install tsu globally
  * @returns The detected package manager or null if not found
  */
 /* v8 ignore next -- @preserve */
 export function detectPackageManager(): 'npm' | 'pnpm' | 'yarn' | null {
   try {
-    // Check which package manager has tsutils installed
+    // Check which package manager has tsu installed
     const whichTsu = execSync('which tsu', { encoding: 'utf-8' }).trim();
 
     if (whichTsu.includes('/Library/pnpm/') || whichTsu.includes('/.local/share/pnpm/')) {
@@ -135,7 +135,7 @@ function isValidGitHubName(name: string): boolean {
 }
 
 /**
- * Upgrade tsutils by installing from GitHub
+ * Upgrade tsu by installing from GitHub
  * @param owner - GitHub repository owner
  * @param repo - GitHub repository name
  * @param packageManager - Package manager to use (npm, pnpm, or yarn). If not provided, will try to detect, defaulting to pnpm.


### PR DESCRIPTION
## Why

This package declared `"name": "tsutils"`, which collides with the real, widely-used [`tsutils`](https://www.npmjs.com/package/tsutils) TypeScript utility library. Installing this CLI globally claimed that name at `/opt/homebrew/lib/node_modules/tsutils`, and the `tsutils` bin entry duplicated the collision on the executable itself.

The collision also caused a concrete failure: a half-finished install left a stale symlink at that path pointing into the npm cache, and every later `npm install -g github:bestdan/tsu` died with `ENOTDIR: not a directory, rename '/opt/homebrew/lib/node_modules/tsutils' -> ...`.

## What

- `package.json`: `name` → `@bestdan/tsu`, version → `0.26.0`, `tsutils` bin entry removed (only `tsu` remains).
- CLI program name, help/usage text, docs, and comments referring to this tool: `tsutils` → `tsu`.

Nothing keys off the package name at runtime — `src/utils/version.ts` detects the package manager via `which tsu`, and upgrade installs from `github:owner/repo`, never the npm registry — so this is a naming and user-facing-text change only. Install instructions stay as GitHub specs; this package is still not published to npm.

Test fixtures under `src/__fixtures__/` keep their unrelated `tsutils` strings.

## Verification

- `pnpm run build`, `pnpm run typecheck`, `pnpm run lint` — clean.
- `pnpm run test:run` — 443 passed, 9 skipped, 1 todo, 0 failed (run with `GIT_CONFIG_GLOBAL=/dev/null`; without it, git-fixture tests trip the machine-wide no-commit-to-`main` pre-commit hook).
- `node dist/cli.js --help` → `Usage: tsu [options] [command]`.

## Follow-up

Once merged, this gets tagged `v0.26.0` and `bestdan/dotfiles`' `setup.sh` pins the install to that tag instead of tracking the default branch.
